### PR TITLE
Corrigindo responsividade dos botões de sistema operacional

### DIFF
--- a/docs/.vuepress/components/CardButton.vue
+++ b/docs/.vuepress/components/CardButton.vue
@@ -21,8 +21,7 @@ export default {
 .card
     flex-grow 1
     border 1px solid #80808042
-    margin-right 0.5rem
-    margin-left 0.5rem
+    margin 0.5rem
     border-radius 4px
     cursor pointer
     text-decoration none !important

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -2,6 +2,10 @@
 
 .card-deck
   display flex
+  flex-direction: column
+  @media (min-width: 719px)
+    flex-direction: row
+
 
 .tip
   border-color #0c5460 !important 


### PR DESCRIPTION
Em telas menores a responsividade dos botões de sistema operacional na instalação ficava ruim.
Alterado para exibir em forma de coluna.